### PR TITLE
Feature/upgrade pjsip to 2.5.5 and open ssl to 1.0.2h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-pjproject-2.4.5
-openssl-1.0.2g
+pjproject-2.5.5
+openssl-1.0.2h
 openh264-1.0.0
 libyuv-android
 android-ndk-r10e

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Easily build PJSIP with: OpenSSL, OpenH264, libyuv and G.729 (without Intel IPP)
 
 | Library \ Builds for | armeabi | armeabi-v7a | x86 | mips | arm64-v8a  | x86_64 | mips64 |
 |----------------------|---------|-------------|-----|------|------------|--------|--------|
-| [PJSIP 2.4.5](https://trac.pjsip.org/repos/browser/pjproject/tags/2.4.5)          |    X    |      X      |  X  |   X  |          |      |      |
+| [PJSIP 2.5.5](https://trac.pjsip.org/repos/browser/pjproject/tags/2.5.5)          |    X    |      X      |  X  |   X  |          |      |      |
 | [LibYUV r1580](https://github.com/illuspas/libyuv-android)         |    X    |      X      |  X  |     |           |      |      |
 | [G.729](https://github.com/gotev/pjsip-android-builder/tree/master/g729_patch)                |    X    |      X      |  X  |   X  |           |       |       |
-| [OpenSSL 1.0.2g](https://www.openssl.org/source/)       |    X    |      X      |  X  |   X  |           |       |        |
+| [OpenSSL 1.0.2h](https://www.openssl.org/source/)       |    X    |      X      |  X  |   X  |           |       |        |
 | [OpenH264 1.0.0](https://github.com/cisco/openh264/releases/tag/v1.0.0)       |    X    |      X      |  X  |   X  |            |        |        |
 If you want to compile LibYUV for mips, check why it has been disabled in [#12](https://github.com/gotev/pjsip-android-builder/issues/12).
 
@@ -17,10 +17,10 @@ If you want to compile LibYUV for mips, check why it has been disabled in [#12](
 
 | Library \ Builds for | armeabi | armeabi-v7a | x86 | mips | arm64-v8a  | x86_64 | mips64 |
 |----------------------|---------|-------------|-----|------|------------|--------|--------|
-| [PJSIP 2.4.5](https://trac.pjsip.org/repos/browser/pjproject/tags/2.4.5)          |    X    |      X      |  X  |   X  |      X     |    X   |    X   |
+| [PJSIP 2.5.5](https://trac.pjsip.org/repos/browser/pjproject/tags/2.5.5)          |    X    |      X      |  X  |   X  |      X     |    X   |    X   |
 | [LibYUV r1580](https://github.com/illuspas/libyuv-android)         |    X    |      X      |  X  |   X  |      X     |    X   |    X   |
 | [G.729](https://github.com/gotev/pjsip-android-builder/tree/master/g729_patch)                |    X    |      X      |  X  |   X  |      X     |    X   |    X   |
-| [OpenSSL 1.0.2g](https://www.openssl.org/source/)       |    X    |      X      |  X  |   X  |      X     |    X   |        |
+| [OpenSSL 1.0.2h](https://www.openssl.org/source/)       |    X    |      X      |  X  |   X  |      X     |    X   |        |
 | [OpenH264 1.0.0](https://github.com/cisco/openh264/releases/tag/v1.0.0)       |    X    |      X      |  X  |   X  |            |        |        |
 
 OpenSSL and OpenH264 have problems with 64 bit archs, as you can see from the build compatibility matrix. Check [#2](https://github.com/gotev/pjsip-android-builder/issues/2) and [#8](https://github.com/gotev/pjsip-android-builder/issues/8) for further reference. 64 bit builds are supported starting from Android API 21+, so if you compile using older Android APIs, you can do that only for: `armeabi`, `armeabi-v7a`, `x86` and `mips`. 

--- a/config.conf
+++ b/config.conf
@@ -26,11 +26,11 @@ SWIG_DOWNLOAD_URL="http://prdownloads.sourceforge.net/swig/swig-3.0.7.tar.gz"
 SWIG_DIR_NAME="swig-3.0.7"
 
 #The URL from which to download OpenSSL sources tag
-OPENSSL_DOWNLOAD_URL="https://www.openssl.org/source/openssl-1.0.2g.tar.gz"
+OPENSSL_DOWNLOAD_URL="https://www.openssl.org/source/openssl-1.0.2h.tar.gz"
 
 #The name of the folder generated when untarring OpenSSL sources file
 #In general, the name corresponds to that of the tar, except the file extension
-OPENSSL_DIR_NAME="openssl-1.0.2g"
+OPENSSL_DIR_NAME="openssl-1.0.2h"
 
 #The output directory where to store OpenSSL compiled libraries
 OPENSSL_BUILD_OUT_PATH=$(pwd)"/openssl-build-output"

--- a/config.conf
+++ b/config.conf
@@ -12,11 +12,11 @@ SDK_DOWNLOAD_URL="http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz"
 SDK_DIR_NAME="android-sdk-linux"
 
 #The URL from which to download PJSIP sources tag
-PJSIP_DOWNLOAD_URL="http://www.pjsip.org/release/2.4.5/pjproject-2.4.5.tar.bz2"
+PJSIP_DOWNLOAD_URL="http://www.pjsip.org/release/2.5.5/pjproject-2.5.5.tar.bz2"
 
 #The name of the folder generated when untarring PJSIP sources file
 #In general, the name corresponds to that of the tar, except the file extension
-PJSIP_DIR_NAME="pjproject-2.4.5"
+PJSIP_DIR_NAME="pjproject-2.5.5"
 
 #The URL from which to download SWIG sources tar
 SWIG_DOWNLOAD_URL="http://prdownloads.sourceforge.net/swig/swig-3.0.7.tar.gz"

--- a/config.conf
+++ b/config.conf
@@ -61,7 +61,8 @@ LIBYUV_REPO_DIR_NAME="libyuv-android"
 #uncomment the following one if you want to build for 64 bit archs. Bear in mind that
 #to build for 64 bit you have to use Android API 21+ and not all the libraries support that.
 #check the build compatibility matrix in the readme and in the issues for further reference.
-TARGET_ARCHS=("armeabi" "armeabi-v7a" "x86")
+TARGET_ARCHS=("armeabi" "armeabi-v7a")
+#TARGET_ARCHS=("armeabi" "armeabi-v7a" "x86")
 #TARGET_ARCHS=("armeabi" "armeabi-v7a" "x86" "mips")
 #TARGET_ARCHS=("armeabi" "armeabi-v7a" "x86" "mips" "arm64-v8a" "x86_64" "mips64")
 

--- a/g729_patch/g729.patch
+++ b/g729_patch/g729.patch
@@ -1,6 +1,6 @@
-diff -Naur pjproject-2.4.5/aconfigure.ac pjproject-2.4.5/aconfigure.ac
---- pjproject-2.4.5/aconfigure.ac	2015-12-27 11:12:49.000000000 +0000
-+++ pjproject-2.4.5/aconfigure.ac	2015-12-27 11:18:36.000000000 +0000
+diff -Naur pjproject-2.5.5/aconfigure.ac pjproject-2.5.5/aconfigure.ac
+--- pjproject-2.5.5/aconfigure.ac	2015-12-27 11:12:49.000000000 +0000
++++ pjproject-2.5.5/aconfigure.ac	2015-12-27 11:18:36.000000000 +0000
 @@ -1255,6 +1255,20 @@
  			       )
  	      ])
@@ -22,9 +22,9 @@ diff -Naur pjproject-2.4.5/aconfigure.ac pjproject-2.4.5/aconfigure.ac
 
  dnl ########################################################
  dnl # Intel IPP support
-diff -Naur pjproject-2.4.5/build.mak.in pjproject-2.4.5/build.mak.in
---- pjproject-2.4.5/build.mak.in	2015-12-27 11:12:49.000000000 +0000
-+++ pjproject-2.4.5/build.mak.in	2015-12-27 11:14:10.000000000 +0000
+diff -Naur pjproject-2.5.5/build.mak.in pjproject-2.5.5/build.mak.in
+--- pjproject-2.5.5/build.mak.in	2015-12-27 11:12:49.000000000 +0000
++++ pjproject-2.5.5/build.mak.in	2015-12-27 11:14:10.000000000 +0000
 @@ -106,6 +106,11 @@
  endif
  endif
@@ -37,9 +37,9 @@ diff -Naur pjproject-2.4.5/build.mak.in pjproject-2.4.5/build.mak.in
  ifneq ($(findstring pa,@ac_pjmedia_snd@),)
  ifeq (@ac_external_pa@,1)
  # External PA
-diff -Naur pjproject-2.4.5/pjmedia/build/os-auto.mak.in pjproject-2.4.5/pjmedia/build/os-auto.mak.in
---- pjproject-2.4.5/pjmedia/build/os-auto.mak.in	2015-12-27 11:12:50.000000000 +0000
-+++ pjproject-2.4.5/pjmedia/build/os-auto.mak.in	2015-12-27 11:15:24.000000000 +0000
+diff -Naur pjproject-2.5.5/pjmedia/build/os-auto.mak.in pjproject-2.5.5/pjmedia/build/os-auto.mak.in
+--- pjproject-2.5.5/pjmedia/build/os-auto.mak.in	2015-12-27 11:12:50.000000000 +0000
++++ pjproject-2.5.5/pjmedia/build/os-auto.mak.in	2015-12-27 11:15:24.000000000 +0000
 @@ -72,6 +72,7 @@
  AC_NO_ILBC_CODEC=@ac_no_ilbc_codec@
  AC_NO_G722_CODEC=@ac_no_g722_codec@
@@ -62,9 +62,9 @@ diff -Naur pjproject-2.4.5/pjmedia/build/os-auto.mak.in pjproject-2.4.5/pjmedia/
  ifeq ($(AC_NO_OPENCORE_AMRNB),1)
  export CFLAGS += -DPJMEDIA_HAS_OPENCORE_AMRNB_CODEC=0
  else
-diff -Naur pjproject-2.4.5/pjmedia/include/pjmedia-codec/config_auto.h.in pjproject-2.4.5/pjmedia/include/pjmedia-codec/config_auto.h.in
---- pjproject-2.4.5/pjmedia/include/pjmedia-codec/config_auto.h.in	2015-12-27 11:12:51.000000000 +0000
-+++ pjproject-2.4.5/pjmedia/include/pjmedia-codec/config_auto.h.in	2015-12-27 11:17:16.000000000 +0000
+diff -Naur pjproject-2.5.5/pjmedia/include/pjmedia-codec/config_auto.h.in pjproject-2.5.5/pjmedia/include/pjmedia-codec/config_auto.h.in
+--- pjproject-2.5.5/pjmedia/include/pjmedia-codec/config_auto.h.in	2015-12-27 11:12:51.000000000 +0000
++++ pjproject-2.5.5/pjmedia/include/pjmedia-codec/config_auto.h.in	2015-12-27 11:17:16.000000000 +0000
 @@ -69,6 +69,11 @@
  #undef PJMEDIA_HAS_G7221_CODEC
  #endif
@@ -77,9 +77,9 @@ diff -Naur pjproject-2.4.5/pjmedia/include/pjmedia-codec/config_auto.h.in pjproj
  /* OpenCORE AMR-NB codec */
  #ifndef PJMEDIA_HAS_OPENCORE_AMRNB_CODEC
  #undef PJMEDIA_HAS_OPENCORE_AMRNB_CODEC
-diff -Naur pjproject-2.4.5/pjmedia/include/pjmedia-codec/config.h pjproject-2.4.5/pjmedia/include/pjmedia-codec/config.h
---- pjproject-2.4.5/pjmedia/include/pjmedia-codec/config.h	2015-12-27 11:12:51.000000000 +0000
-+++ pjproject-2.4.5/pjmedia/include/pjmedia-codec/config.h	2015-12-27 11:16:28.000000000 +0000
+diff -Naur pjproject-2.5.5/pjmedia/include/pjmedia-codec/config.h pjproject-2.5.5/pjmedia/include/pjmedia-codec/config.h
+--- pjproject-2.5.5/pjmedia/include/pjmedia-codec/config.h	2015-12-27 11:12:51.000000000 +0000
++++ pjproject-2.5.5/pjmedia/include/pjmedia-codec/config.h	2015-12-27 11:16:28.000000000 +0000
 @@ -96,6 +96,12 @@
  #   define PJMEDIA_HAS_G722_CODEC    1
  #endif
@@ -93,9 +93,9 @@ diff -Naur pjproject-2.4.5/pjmedia/include/pjmedia-codec/config.h pjproject-2.4.
 
  /**
   * Default G.722 codec encoder and decoder level adjustment. The G.722
-diff -Naur pjproject-2.4.5/pjmedia/include/pjmedia-codec.h pjproject-2.4.5/pjmedia/include/pjmedia-codec.h
---- pjproject-2.4.5/pjmedia/include/pjmedia-codec.h	2015-12-27 11:12:51.000000000 +0000
-+++ pjproject-2.4.5/pjmedia/include/pjmedia-codec.h	2015-12-27 11:17:48.000000000 +0000
+diff -Naur pjproject-2.5.5/pjmedia/include/pjmedia-codec.h pjproject-2.5.5/pjmedia/include/pjmedia-codec.h
+--- pjproject-2.5.5/pjmedia/include/pjmedia-codec.h	2015-12-27 11:12:51.000000000 +0000
++++ pjproject-2.5.5/pjmedia/include/pjmedia-codec.h	2015-12-27 11:17:48.000000000 +0000
 @@ -33,6 +33,7 @@
  #include <pjmedia-codec/ilbc.h>
  #include <pjmedia-codec/g722.h>
@@ -104,9 +104,9 @@ diff -Naur pjproject-2.4.5/pjmedia/include/pjmedia-codec.h pjproject-2.4.5/pjmed
  #include <pjmedia-codec/ipp_codecs.h>
  #include <pjmedia-codec/opencore_amr.h>
  #include <pjmedia-codec/openh264.h>
-diff -Naur pjproject-2.4.5/pjmedia/src/pjmedia-codec/audio_codecs.c pjproject-2.4.5/pjmedia/src/pjmedia-codec/audio_codecs.c
---- pjproject-2.4.5/pjmedia/src/pjmedia-codec/audio_codecs.c	2015-12-27 11:12:51.000000000 +0000
-+++ pjproject-2.4.5/pjmedia/src/pjmedia-codec/audio_codecs.c	2015-12-27 11:20:05.000000000 +0000
+diff -Naur pjproject-2.5.5/pjmedia/src/pjmedia-codec/audio_codecs.c pjproject-2.5.5/pjmedia/src/pjmedia-codec/audio_codecs.c
+--- pjproject-2.5.5/pjmedia/src/pjmedia-codec/audio_codecs.c	2015-12-27 11:12:51.000000000 +0000
++++ pjproject-2.5.5/pjmedia/src/pjmedia-codec/audio_codecs.c	2015-12-27 11:20:05.000000000 +0000
 @@ -100,6 +100,13 @@
  	return status;
  #endif /* PJMEDIA_HAS_G7221_CODEC */
@@ -121,9 +121,9 @@ diff -Naur pjproject-2.4.5/pjmedia/src/pjmedia-codec/audio_codecs.c pjproject-2.
  #if PJMEDIA_HAS_L16_CODEC
      /* Register L16 family codecs */
      status = pjmedia_codec_l16_init(endpt, 0);
-diff -Naur pjproject-2.4.5/third_party/build/os-auto.mak.in pjproject-2.4.5/third_party/build/os-auto.mak.in
---- pjproject-2.4.5/third_party/build/os-auto.mak.in	2015-12-27 11:12:54.000000000 +0000
-+++ pjproject-2.4.5/third_party/build/os-auto.mak.in	2015-12-27 11:20:46.000000000 +0000
+diff -Naur pjproject-2.5.5/third_party/build/os-auto.mak.in pjproject-2.5.5/third_party/build/os-auto.mak.in
+--- pjproject-2.5.5/third_party/build/os-auto.mak.in	2015-12-27 11:12:54.000000000 +0000
++++ pjproject-2.5.5/third_party/build/os-auto.mak.in	2015-12-27 11:20:46.000000000 +0000
 @@ -23,6 +23,10 @@
  DIRS += g7221
  endif

--- a/g729_patch/install.sh
+++ b/g729_patch/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-PJPROJECT_BASE_FOLDER="../pjproject-2.4.5"
+PJPROJECT_BASE_FOLDER="../pjproject-2.5.5"
 
 cp g729.patch ../
 CURDIR=$(pwd)


### PR DESCRIPTION
upgrade:
- [x] pjsip from 2.4.5 to 2.5.5
- [x] openSSL from 1.0.2g to 1.0.2h

problems
- [ ] can't build PJSUA Java wrapper when x86 is enabled. For now I disabled the x86 build. Can someone help me why this happens?
