### PR TITLE
Modify pre-build-system, install java 12 instead of 8

### DIFF
--- a/prepare-build-system
+++ b/prepare-build-system
@@ -22,13 +22,13 @@ export PATH="$NDK_TOOLCHAIN_VERSION:$PATH"
 
 if [ "$SETUP_PACKAGES" == "1" ]
 then
-    # Setup Java 12
+    # Setup Java 13
     sudo apt update
     sudo apt upgrade
     sudo add-apt-repository ppa:linuxuprising/java
     sudo apt update
-    sudo apt install oracle-java12-installer
-    sudo apt install oracle-java12-set-default
+    sudo apt install oracle-java13-installer
+    sudo apt install oracle-java13-set-default
     sudo apt-get install -y unzip git
 
     DEPS="vim git curl bzip2 gcc g++ binutils make autoconf openssl \

--- a/prepare-build-system
+++ b/prepare-build-system
@@ -22,14 +22,13 @@ export PATH="$NDK_TOOLCHAIN_VERSION:$PATH"
 
 if [ "$SETUP_PACKAGES" == "1" ]
 then
-    # Setup Java 8
-    sudo add-apt-repository -y ppa:webupd8team/java
-    sudo apt-get update
-    sudo apt-get purge -y openjdk*
-    echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-    sudo apt-get -y install oracle-java8-installer ant
-
+    # Setup Java 12
+    sudo apt update
+    sudo apt upgrade
+    sudo add-apt-repository ppa:linuxuprising/java
+    sudo apt update
+    sudo apt install oracle-java12-installer
+    sudo apt install oracle-java12-set-default
     sudo apt-get install -y unzip git
 
     DEPS="vim git curl bzip2 gcc g++ binutils make autoconf openssl \


### PR DESCRIPTION
The pre-build-system breaks when trying to install java 8 because Oracle JDK License has changed for releases starting April 16, 2019.
http://www.webupd8.org/2014/03/how-to-install-oracle-java-8-in-debian.html